### PR TITLE
Marathon app group plugin

### DIFF
--- a/seed/xylem/gluster.py
+++ b/seed/xylem/gluster.py
@@ -5,8 +5,8 @@ from rhumba import RhumbaPlugin
 from rhumba.utils import fork
 
 class Plugin(RhumbaPlugin):
-    def __init__(self, *a):
-        super(Plugin, self).__init__(*a)
+    def __init__(self, *args, **kw):
+        super(Plugin, self).__init__(*args, **kw)
 
         self.gluster_path = self.config.get('gluster_path', '/usr/sbin/gluster')
         self.gluster_nodes = self.config['gluster_nodes']

--- a/seed/xylem/marathon_sync.py
+++ b/seed/xylem/marathon_sync.py
@@ -1,0 +1,47 @@
+from twisted.internet.defer import gatherResults
+from twisted.web.client import getPage
+from twisted.web.http_headers import Headers
+
+from rhumba import RhumbaPlugin, cron
+
+
+class Plugin(RhumbaPlugin):
+    """
+    A plugin to periodically push an application group definition to Marathon.
+    """
+
+    def __init__(self, *args, **kw):
+        super(Plugin, self).__init__(*args, **kw)
+
+        self.marathon_host = self.config.get("marathon_host", "localhost")
+        self.marathon_port = self.config.get("marathon_port", "8080")
+        self.group_json_files = self.config["group_json_files"]
+
+    # @cron(min="*/1")
+    @cron(secs="*/10")
+    def call_do_thing(self, args):
+        self.log("Did thing: %r" % (args,))
+        return self.call_update_groups()
+
+    def call_update_groups(self):
+        ds = []
+        for group_json_file in self.group_json_files:
+            ds.append(self.call_update_group(group_json_file))
+        return gatherResults(ds)
+
+    def call_update_group(self, group_json_file):
+        self.log("Updating %r" % (group_json_file,))
+        with open(group_json_file) as f:
+            body = f.read()
+        d = self._call_marathon("PUT", "v2/groups", body)
+        d.addBoth(self._logcb)
+        return d
+
+    def _logcb(self, r, msg=" ... result: %r"):
+        self.log(msg % (r,))
+        return r
+
+    def _call_marathon(self, method, path, body=None):
+        uri = b"http://%s:%s/%s" % (
+            self.marathon_host, self.marathon_port, path)
+        return getPage(uri, method=method, postdata=body)

--- a/seed/xylem/marathon_sync.py
+++ b/seed/xylem/marathon_sync.py
@@ -1,6 +1,5 @@
 from twisted.internet.defer import gatherResults
 from twisted.web.client import getPage
-from twisted.web.http_headers import Headers
 
 from rhumba import RhumbaPlugin, cron
 
@@ -10,6 +9,8 @@ class Plugin(RhumbaPlugin):
     A plugin to periodically push an application group definition to Marathon.
     """
 
+    getPage = getPage  # To stub out in tests.
+
     def __init__(self, *args, **kw):
         super(Plugin, self).__init__(*args, **kw)
 
@@ -17,8 +18,7 @@ class Plugin(RhumbaPlugin):
         self.marathon_port = self.config.get("marathon_port", "8080")
         self.group_json_files = self.config["group_json_files"]
 
-    # @cron(min="*/1")
-    @cron(secs="*/10")
+    @cron(min="*/1")
     def call_do_thing(self, args):
         self.log("Did thing: %r" % (args,))
         return self.call_update_groups()
@@ -31,8 +31,7 @@ class Plugin(RhumbaPlugin):
 
     def call_update_group(self, group_json_file):
         self.log("Updating %r" % (group_json_file,))
-        with open(group_json_file) as f:
-            body = f.read()
+        body = self.readfile(group_json_file)
         d = self._call_marathon("PUT", "v2/groups", body)
         d.addBoth(self._logcb)
         return d
@@ -44,4 +43,11 @@ class Plugin(RhumbaPlugin):
     def _call_marathon(self, method, path, body=None):
         uri = b"http://%s:%s/%s" % (
             self.marathon_host, self.marathon_port, path)
-        return getPage(uri, method=method, postdata=body)
+        return self.getPage(uri, method=method, postdata=body)
+
+    def readfile(self, filepath):
+        """
+        Read a file and return its content.
+        """
+        with open(filepath, "r") as f:
+            return f.read()

--- a/seed/xylem/postgres.py
+++ b/seed/xylem/postgres.py
@@ -17,8 +17,8 @@ from rhumba import RhumbaPlugin
 from rhumba.utils import fork
 
 class Plugin(RhumbaPlugin):
-    def __init__(self, *a):
-        super(Plugin, self).__init__(*a)
+    def __init__(self, *args, **kw):
+        super(Plugin, self).__init__(*args, **kw)
 
         self.servers = self.config['servers']
 

--- a/seed/xylem/tests/test_marathon_sync.py
+++ b/seed/xylem/tests/test_marathon_sync.py
@@ -35,5 +35,5 @@ class TestMarathonSync(TestCase):
             "http://localhost:8080/v2/groups", "PUT",
             '{"id": "/t", "apps": []}',
             '{"version":"vvv","deploymentId":"ddd"}')
-        resp = yield plugin.call_update_group("foo.json")
+        resp = yield plugin.call_update_group({"group_json_file": "foo.json"})
         self.assertEqual(resp, '{"version":"vvv","deploymentId":"ddd"}')

--- a/seed/xylem/tests/test_marathon_sync.py
+++ b/seed/xylem/tests/test_marathon_sync.py
@@ -1,0 +1,39 @@
+from twisted.internet.defer import succeed, inlineCallbacks
+from twisted.trial.unittest import TestCase
+
+from seed.xylem import marathon_sync
+
+
+class TestMarathonSync(TestCase):
+    def get_plugin(self, **kw):
+        kw.setdefault("name", "marathon_sync")
+        return marathon_sync.Plugin(kw, None)
+
+    def fake_getPage(self, e_url, e_method, e_postdata, resp):
+        def getPage(url, method, postdata):
+            self.assertEqual(url, e_url)
+            self.assertEqual(method, e_method)
+            self.assertEqual(postdata, e_postdata)
+            return succeed(resp)
+        return getPage
+
+    def fake_readfile(self, fn_content_mapping):
+        def readfile(filepath):
+            return fn_content_mapping[filepath]
+        return readfile
+
+    @inlineCallbacks
+    def test_update_group(self):
+        """
+        call_update_group makes an appropriate Marathon API request.
+        """
+        plugin = self.get_plugin(group_json_files=[])
+        plugin.readfile = self.fake_readfile({
+            "foo.json": '{"id": "/t", "apps": []}',
+        })
+        plugin.getPage = self.fake_getPage(
+            "http://localhost:8080/v2/groups", "PUT",
+            '{"id": "/t", "apps": []}',
+            '{"version":"vvv","deploymentId":"ddd"}')
+        resp = yield plugin.call_update_group("foo.json")
+        self.assertEqual(resp, '{"version":"vvv","deploymentId":"ddd"}')

--- a/seed/xylem/tests/test_marathon_sync.py
+++ b/seed/xylem/tests/test_marathon_sync.py
@@ -9,12 +9,9 @@ class TestMarathonSync(TestCase):
         kw.setdefault("name", "marathon_sync")
         return marathon_sync.Plugin(kw, None)
 
-    def fake_getPage(self, e_url, e_method, e_postdata, resp):
+    def fake_getPage(self, req_mapping):
         def getPage(url, method, postdata):
-            self.assertEqual(url, e_url)
-            self.assertEqual(method, e_method)
-            self.assertEqual(postdata, e_postdata)
-            return succeed(resp)
+            return succeed(req_mapping[(url, method, postdata)])
         return getPage
 
     def fake_readfile(self, fn_content_mapping):
@@ -31,9 +28,33 @@ class TestMarathonSync(TestCase):
         plugin.readfile = self.fake_readfile({
             "foo.json": '{"id": "/t", "apps": []}',
         })
-        plugin.getPage = self.fake_getPage(
-            "http://localhost:8080/v2/groups", "PUT",
-            '{"id": "/t", "apps": []}',
-            '{"version":"vvv","deploymentId":"ddd"}')
+        req = ("http://localhost:8080/v2/groups", "PUT",
+               '{"id": "/t", "apps": []}')
+        plugin.getPage = self.fake_getPage({
+            req: '{"version":"vvv","deploymentId":"ddd"}',
+        })
         resp = yield plugin.call_update_group({"group_json_file": "foo.json"})
         self.assertEqual(resp, '{"version":"vvv","deploymentId":"ddd"}')
+
+    @inlineCallbacks
+    def test_update_groups(self):
+        """
+        call_update_group makes an appropriate Marathon API request.
+        """
+        plugin = self.get_plugin(group_json_files=["foo.json", "bar.json"])
+        plugin.readfile = self.fake_readfile({
+            "foo.json": '{"id": "/f", "apps": []}',
+            "bar.json": '{"id": "/b", "apps": []}',
+        })
+        fooreq = ("http://localhost:8080/v2/groups", "PUT",
+                  '{"id": "/f", "apps": []}')
+        barreq = ("http://localhost:8080/v2/groups", "PUT",
+                  '{"id": "/b", "apps": []}')
+        plugin.getPage = self.fake_getPage({
+            fooreq: '{"version":"vvv","deploymentId":"dddf"}',
+            barreq: '{"version":"vvv","deploymentId":"dddb"}',
+        })
+        resp = yield plugin.call_update_groups({})
+        self.assertEqual(sorted(resp), sorted([
+            '{"version":"vvv","deploymentId":"dddf"}',
+            '{"version":"vvv","deploymentId":"dddb"}']))

--- a/seed/xylem/tests/test_store.py
+++ b/seed/xylem/tests/test_store.py
@@ -10,7 +10,7 @@ class Gluster(unittest.TestCase):
             'name': 'gluster', 
             'gluster_nodes': ['test'],
             'gluster_mounts': ['/data'],
-        })
+        }, None)
 
         self.plug.callGluster = lambda *args: defer.maybeDeferred(
             self.fakeGlusterCommand, *args)
@@ -69,7 +69,7 @@ class Postgres(unittest.TestCase):
             'servers': [{
                 'hostname': 'localhost'
             }]
-        })
+        }, None)
 
     def test_pwgens(self):
         enc = self.plug._encrypt('Test string')


### PR DESCRIPTION
A plugin that periodically sends app group definitions to Marathon would be useful for managing "infrastructure" containers.
