### PR TITLE
GREENHOUSE-62 Handle stopped volumes

### DIFF
--- a/seed/xylem/gluster.py
+++ b/seed/xylem/gluster.py
@@ -68,7 +68,7 @@ class Plugin(RhumbaPlugin):
         """ Gets volume information from glusterfs on this server
         """
         def catch_missing_volume(f):
-            if f.value.args[0].endswith('does not exist'):
+            if f.value.args[0].strip().endswith('does not exist'):
                 return None
             return f
 

--- a/seed/xylem/gluster.py
+++ b/seed/xylem/gluster.py
@@ -29,11 +29,12 @@ class Plugin(RhumbaPlugin):
             defer.returnValue(out.strip('\n').split('\n'))
 
     @defer.inlineCallbacks
-    def getVolumes(self):
+    def getVolumes(self, name=None):
         """ Gets volume information from glusterfs on this server
         """
 
-        volumeInfo = yield self.callGluster('volume', 'info')
+        args = [] if name is None else [name]
+        volumeInfo = yield self.callGluster('volume', 'info', *args)
 
         vols = {}
 

--- a/seed/xylem/tests/test_gluster.py
+++ b/seed/xylem/tests/test_gluster.py
@@ -49,7 +49,7 @@ class FakeGluster(object):
     def cmd_volume_info(self, name=None):
         if name:
             if name not in self.volumes:
-                raise Exception('Volume {0} does not exist'.format(name))
+                raise Exception('Volume {0} does not exist\n'.format(name))
             vols = [self.volumes[name]]
         else:
             vols = self.volumes.values()

--- a/seed/xylem/tests/test_gluster.py
+++ b/seed/xylem/tests/test_gluster.py
@@ -1,7 +1,52 @@
+from uuid import uuid4
+
 from twisted.internet import defer
 from twisted.trial.unittest import TestCase
 
 from seed.xylem import gluster
+
+
+class FakeVolume(object):
+    def __init__(self, name, bricks, volume_id=None):
+        self.name = name
+        self.bricks = list(bricks)
+        if volume_id is None:
+            volume_id = str(uuid4())
+        self.volume_id = volume_id
+
+    def info(self):
+        return [
+            '',
+            'Volume Name: {0}'.format(self.name),
+            'Type: Distribute',
+            'Volume ID: {0}'.format(self.volume_id),
+            'Status: Started',
+            'Number of Bricks: {0}'.format(len(self.bricks)),
+            'Transport-type: tcp',
+            'Bricks:',
+        ] + ['Brick{0}: {1}'.format(i+1, brick)
+             for i, brick in enumerate(self.bricks)] + [
+            'Options Reconfigured:',
+            'performance.readdir-ahead: on',
+        ]
+
+
+class FakeGluster(object):
+    def __init__(self):
+        self.volumes = {}
+
+    def add_volume(self, name, *args, **kw):
+        assert name not in self.volumes
+        vol = FakeVolume(name, *args, **kw)
+        self.volumes[name] = vol
+        return vol
+
+    def cmd_volume_info(self):
+        return sum([vol.info() for vol in self.volumes.values()], [])
+
+    def call(self, cmd0, cmd1, *args):
+        meth = getattr(self, '_'.join(['cmd', cmd0, cmd1]))
+        return meth(*args)
 
 
 class TestGlusterPlugin(TestCase):
@@ -12,50 +57,29 @@ class TestGlusterPlugin(TestCase):
             'gluster_mounts': ['/data'],
         }, None)
 
+        self.fake_gluster = FakeGluster()
         self.plug.callGluster = lambda *args: defer.maybeDeferred(
-            self.fakeGlusterCommand, *args)
-
-    def fakeGlusterCommand(self, *args):
-        if args[0] == 'volume' and args[1] == 'info':
-            return [
-                '',
-                'Volume Name: gv0',
-                'Type: Distribute',
-                'Volume ID: 8368a90e-2137-49d6-aa7f-377710018c88',
-                'Status: Started',
-                'Number of Bricks: 1',
-                'Transport-type: tcp',
-                'Bricks:',
-                'Brick1: qa-mesos-persistence:/data/testbrick',
-                'Options Reconfigured:',
-                'performance.readdir-ahead: on',
-                '',
-                'Volume Name: gv2',
-                'Type: Distribute',
-                'Volume ID: 8bda3daa-4fe8-4021-8acd-4100ea2833fb',
-                'Status: Started',
-                'Number of Bricks: 1',
-                'Transport-type: tcp',
-                'Bricks:',
-                'Brick1: qa-mesos-persistence:/data/br-gv2',
-                'Options Reconfigured:',
-                'performance.readdir-ahead: on'
-            ]
-
-        return []
+            self.fake_gluster.call, *args)
 
     @defer.inlineCallbacks
     def test_volume_info(self):
+        gv0 = self.fake_gluster.add_volume(
+            'gv0', ['qa-mesos-persistence:/data/testbrick'])
+        gv2 = self.fake_gluster.add_volume(
+            'gv2', ['qa-mesos-persistence:/data/br-gv2'])
+
         vols = yield self.plug.getVolumes()
 
-        self.assertEquals(
-            vols['gv0']['id'], '8368a90e-2137-49d6-aa7f-377710018c88')
+        self.assertEquals(vols['gv0']['id'], gv0.volume_id)
+        self.assertEquals(vols['gv2']['id'], gv2.volume_id)
 
     @defer.inlineCallbacks
     def test_volume_create(self):
         self.plug.gluster_mounts = ['/data1', '/data2']
         self.plug.gluster_stripe = 2
         create = yield self.plug._createArgs('testvol', createpath=False)
+        print create
+        assert False
 
         self.assertEquals(create[2], 'testvol')
         self.assertEquals(create[3], 'stripe')

--- a/seed/xylem/tests/test_gluster.py
+++ b/seed/xylem/tests/test_gluster.py
@@ -178,3 +178,21 @@ class TestGlusterPlugin(TestCase):
 
         vol = self.fake_gluster.volumes['testvol']
         self.assertEqual(vol.info(), originfo)
+
+    @defer.inlineCallbacks
+    def test_volume_create_stopped(self):
+        """
+        An existing stopped volume is started.
+        """
+        origvol = self.fake_gluster.add_volume(
+            'testvol',
+            status='Stopped',
+            bricks=['test:/data1/xylem-testvol', 'test:/data2/xylem-testvol'])
+        self.assertEqual(origvol.status, 'Stopped')
+
+        self.plug.gluster_mounts = ['/data1', '/data2']
+        self.plug.gluster_stripe = 2
+        yield self.plug.call_createvolume({'name': 'testvol'})
+
+        vol = self.fake_gluster.volumes['testvol']
+        self.assertEqual(vol.status, 'Started')


### PR DESCRIPTION
Sometimes a volume is created but not started, which causes future creates to do nothing (because the volume exists) and all mounts to fail (because the volume is stopped).

The correct behaviour is to check if existing volumes are stopped during creation and start them if they are.